### PR TITLE
modifcando main.pl pra tratar tudo como átomos

### DIFF
--- a/components/prob_algorithm.pl
+++ b/components/prob_algorithm.pl
@@ -3,15 +3,12 @@
 :- use_module(deck).
 :- use_module('../util/auxiliary_functions').
 
-% --- Predicados de Verificação ---
 is_blackjack(Cards) :-
     sum_cards(Cards, 21).
 
 is_overflow(Cards) :-
     sum_cards(Cards, Sum),
     Sum > 21.
-
-% --- Lógica de Probabilidade ---
 
 overflow_prob(Cards, Limit, Deck, Prob) :-
     sum_cards(Cards, CurrentSum),
@@ -53,8 +50,6 @@ blackjack_prob(Cards, Deck, Prob) :-
     total_cards_in_deck(Deck, Total),
     (Total > 0 -> Prob is Count / Total ; Prob = 0.0).
 
-% --- Interface de Cálculo de Média ---
-
 average_prob_user_interface(UserCards, DealerCards, Result) :-
     average_prob_user(UserCards, DealerCards, 50, 0, (0.0, 0.0), Result).
 
@@ -69,12 +64,10 @@ average_prob_user(UserCards, DealerCards, Limit, Iter, (AccGet, AccStay), Result
     NextIter is Iter + 1,
     average_prob_user(UserCards, DealerCards, Limit, NextIter, (NewAccGet, NewAccStay), Result).
 
-% --- Lógica de Simulação por Rodada ---
-
 prob_user(UserCards, DealerCards, (ProbGetTrunc, ProbStayTrunc)) :-
     sum_cards(UserCards, SumUser),
     (   SumUser >= 21 
-    ->  ProbGetTrunc = 0.0, ProbStayTrunc = 100.0 % Segurança extra
+    ->  ProbGetTrunc = 0.0, ProbStayTrunc = 100.0 
     ;   generate_deck(StarterDeck),
         append(UserCards, DealerCards, AllKnown),
         remove_cards(AllKnown, StarterDeck, UpdatedDeck),
@@ -117,8 +110,6 @@ prob_user(UserCards, DealerCards, (ProbGetTrunc, ProbStayTrunc)) :-
         ;   ProbGetTrunc = 0.0, ProbStayTrunc = 100.0
         )
     ).
-
-% --- Ponto de Entrada Principal ---
 
 calculate_probs(UserCards, DealerCards, (FinalGet, FinalStay)) :-
     sum_cards(UserCards, TotalUser),

--- a/main.pl
+++ b/main.pl
@@ -1,19 +1,20 @@
 :- use_module('./util/auxiliary_functions').
+:- use_module('./components/prob_algorithm').
 
 len_dealers_card([_]).
-all_cards_are_valid(X) :- subset(X, ['A', 2, 3, 4, 5, 6, 7, 8, 9, 10, 'J', 'Q', 'K']).
+all_cards_are_valid(X) :- subset(X, ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K']).
 min_len_user_cards(X) :-
     length(X, TAM),
     TAM > 1.
 
 filter_cards_above_interupt(_, _, []). 
 filter_cards_above_interupt(Lista, [H_dealer|_], [H|T]) :-
-    count(H, Lista, Qtd),
+    el_count(H, Lista, Qtd),
     ((H_dealer == H) -> Sum_dealer = 1; Sum_dealer = 0), 
     ((Qtd + Sum_dealer > 4 ) -> false; filter_cards_above_interupt(Lista, [H_dealer], T)). 
 
 check_quantity_card_limits(X, Y) :- 
-    filter_cards_above_interupt(X, Y, ['A', 2, 3, 4, 5, 6, 7, 8, 9, 10, 'J', 'Q', 'K']).
+    filter_cards_above_interupt(X, Y, ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K']).
 
 validate_user_cards(X) :- 
     min_len_user_cards(X),
@@ -34,5 +35,8 @@ main :-
     validate_dealers_card(Y),
 
     check_quantity_card_limits(X, Y),
-    format('Dealers Card: ~w', [Y]), nl.
+    format('Dealers Card: ~w', [Y]), nl,
 
+	calculate_probs(X, Y, (Get, Stay)),
+	format('Get prob: ~w', Get), nl,
+	format('Stay prob: ~w', Stay), nl.

--- a/teste.pl
+++ b/teste.pl
@@ -1,0 +1,3 @@
+:- use_module('./util/auxiliary_functions').
+
+contando(X, L, R) :- el_count(X, L, R).

--- a/util/auxiliary_functions.pl
+++ b/util/auxiliary_functions.pl
@@ -1,10 +1,17 @@
 :- module(auxiliary_functions, [
+	el_count/3,
     truncate_at/3,
     random_int/3,
     split/3,
     sum_cards/2,
     get_str_value/2
     ]).
+
+el_count(_, [], 0) :- !.
+el_count(H, [H|T], R) :-
+	el_count(H, T, R2),
+	R is 1 + R2.
+el_count(H, [_|T], R) :- el_count(H, T, R).
 
 truncate_at(X, N, Result) :-
     Factor is 10 ** N,
@@ -16,7 +23,6 @@ random_int(Low, High, Result) :-
 split(Text, Separator, List) :-
     atomic_list_concat(List, Separator, Text).
 
-% Unificado: Aceita Átomo, String ou Número e retorna o valor de Blackjack
 get_str_value(X, 11) :- member(X, ['A', "A"]), !.
 get_str_value(X, 10) :- member(X, ['J', 'K', 'Q', '10', "J", "K", "Q", "10"]), !.
 get_str_value(X, Result) :-
@@ -25,7 +31,6 @@ get_str_value(X, Result) :-
     ;   string(X) -> number_string(X, Str), number_string(Result, Str)
     ), !.
 
-% Auxiliar para contar Ás independentemente do formato
 is_ace('A').
 is_ace("A").
 


### PR DESCRIPTION
- Basicamente, o que eu fiz foi modificar a lista que era usada nos predicados `all_cards_are_valid` e `check_quantity_card_limits`. Isso porque, nesses predicados, símbolos numéricos eram tratados como inteiros, não como átomos;

- Além disso, criei, em `./util/auxiliary_functions.pl`, um predicado `el_count/3`, que funciona como um _count_ simples. Fiz isso porque o `count` que era usado antes não estava funcionando muito bem;

- Por fim, as probabilidades de ganhar pegando (_Get_) e ficando (_Stay_) já estão indo pro `main.pl`. Basta agora tratá-las criando o arquivo `components/prob_interpreter.pl`.